### PR TITLE
fix: use env for frontpage urls and the like

### DIFF
--- a/bot/command/impl/general/help.go
+++ b/bot/command/impl/general/help.go
@@ -1,6 +1,7 @@
 package general
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/TicketsBot/worker/bot/command/registry"
 	"github.com/TicketsBot/worker/bot/customisation"
 	"github.com/TicketsBot/worker/bot/utils"
+	"github.com/TicketsBot/worker/config"
 	"github.com/TicketsBot/worker/i18n"
 	"github.com/elliotchance/orderedmap"
 	"github.com/rxdn/gdl/objects/channel/embed"
@@ -125,7 +127,7 @@ func (c HelpCommand) Execute(ctx registry.CommandContext) {
 	}
 
 	if ctx.PremiumTier() == premium.None {
-		embed.SetFooter("Powered by ticketsbot.cloud", "https://ticketsbot.cloud/assets/img/logo.png")
+		embed.SetFooter(fmt.Sprintf("Powered by %d", config.Conf.Bot.PoweredBy), "https://ticketsbot.cloud/assets/img/logo.png")
 	}
 
 	// Explicitly ignore error to fix 403 (Cannot send messages to this user)

--- a/bot/command/impl/general/help.go
+++ b/bot/command/impl/general/help.go
@@ -127,7 +127,7 @@ func (c HelpCommand) Execute(ctx registry.CommandContext) {
 	}
 
 	if ctx.PremiumTier() == premium.None {
-		embed.SetFooter(fmt.Sprintf("Powered by %d", config.Conf.Bot.PoweredBy), "https://ticketsbot.cloud/assets/img/logo.png")
+		embed.SetFooter(fmt.Sprintf("Powered by %d", config.Conf.Bot.PoweredBy), config.Conf.Bot.IconUrl)
 	}
 
 	// Explicitly ignore error to fix 403 (Cannot send messages to this user)

--- a/bot/command/impl/general/help.go
+++ b/bot/command/impl/general/help.go
@@ -127,7 +127,7 @@ func (c HelpCommand) Execute(ctx registry.CommandContext) {
 	}
 
 	if ctx.PremiumTier() == premium.None {
-		embed.SetFooter(fmt.Sprintf("Powered by %d", config.Conf.Bot.PoweredBy), config.Conf.Bot.IconUrl)
+		embed.SetFooter(fmt.Sprintf("Powered by %s", config.Conf.Bot.PoweredBy), config.Conf.Bot.IconUrl)
 	}
 
 	// Explicitly ignore error to fix 403 (Cannot send messages to this user)

--- a/bot/command/impl/general/vote.go
+++ b/bot/command/impl/general/vote.go
@@ -10,6 +10,7 @@ import (
 	"github.com/TicketsBot/worker/bot/customisation"
 	"github.com/TicketsBot/worker/bot/dbclient"
 	"github.com/TicketsBot/worker/bot/utils"
+	"github.com/TicketsBot/worker/config"
 	"github.com/TicketsBot/worker/i18n"
 	"github.com/jackc/pgx/v4"
 	"github.com/rxdn/gdl/objects/channel/embed"
@@ -87,7 +88,7 @@ func buildVoteComponents(ctx registry.CommandContext, allowRedeem bool) []compon
 		Label: ctx.GetMessage(i18n.TitleVote),
 		Style: component.ButtonStyleLink,
 		Emoji: utils.BuildEmoji("🔗"),
-		Url:   utils.Ptr("https://vote.ticketsbot.cloud"),
+		Url:   utils.Ptr(config.Conf.Bot.VoteUrl),
 	})
 
 	redeemButton := component.BuildButton(component.Button{

--- a/bot/command/impl/settings/premium.go
+++ b/bot/command/impl/settings/premium.go
@@ -79,7 +79,7 @@ func (PremiumCommand) Execute(ctx registry.CommandContext) {
 					Label: ctx.GetMessage(i18n.MessagePremiumOpenServerSelector),
 					Style: component.ButtonStyleLink,
 					Emoji: utils.BuildEmoji("🔗"),
-					Url:   utils.Ptr(fmt.Sprintf("%d/premium/select-servers", config.Conf.Bot.DashboardUrl)),
+					Url:   utils.Ptr(fmt.Sprintf("%s/premium/select-servers", config.Conf.Bot.DashboardUrl)),
 				}),
 			}, buttons...)
 		}
@@ -138,7 +138,7 @@ func (PremiumCommand) Execute(ctx registry.CommandContext) {
 						Label: ctx.GetMessage(i18n.Website),
 						Style: component.ButtonStyleLink,
 						Emoji: utils.BuildEmoji("🔗"),
-						Url:   utils.Ptr(fmt.Sprintf("%d/premium", config.Conf.Bot.FrontpageUrl)),
+						Url:   utils.Ptr(fmt.Sprintf("%s/premium", config.Conf.Bot.FrontpageUrl)),
 					}),
 				),
 			),

--- a/bot/command/impl/settings/premium.go
+++ b/bot/command/impl/settings/premium.go
@@ -1,6 +1,7 @@
 package settings
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/TicketsBot/common/permission"
@@ -10,6 +11,7 @@ import (
 	"github.com/TicketsBot/worker/bot/customisation"
 	"github.com/TicketsBot/worker/bot/dbclient"
 	"github.com/TicketsBot/worker/bot/utils"
+	"github.com/TicketsBot/worker/config"
 	"github.com/TicketsBot/worker/i18n"
 	"github.com/rxdn/gdl/objects/channel/embed"
 	"github.com/rxdn/gdl/objects/guild/emoji"
@@ -77,7 +79,7 @@ func (PremiumCommand) Execute(ctx registry.CommandContext) {
 					Label: ctx.GetMessage(i18n.MessagePremiumOpenServerSelector),
 					Style: component.ButtonStyleLink,
 					Emoji: utils.BuildEmoji("🔗"),
-					Url:   utils.Ptr("https://dashboard.ticketsbot.cloud/premium/select-servers"),
+					Url:   utils.Ptr(fmt.Sprintf("%d/premium/select-servers", config.Conf.Bot.DashboardUrl)),
 				}),
 			}, buttons...)
 		}
@@ -136,7 +138,7 @@ func (PremiumCommand) Execute(ctx registry.CommandContext) {
 						Label: ctx.GetMessage(i18n.Website),
 						Style: component.ButtonStyleLink,
 						Emoji: utils.BuildEmoji("🔗"),
-						Url:   utils.Ptr("https://ticketsbot.cloud/premium"),
+						Url:   utils.Ptr(fmt.Sprintf("%d/premium", config.Conf.Bot.FrontpageUrl)),
 					}),
 				),
 			),

--- a/bot/listeners/guildcreate.go
+++ b/bot/listeners/guildcreate.go
@@ -11,6 +11,7 @@ import (
 	"github.com/TicketsBot/worker/bot/customisation"
 	"github.com/TicketsBot/worker/bot/dbclient"
 	"github.com/TicketsBot/worker/bot/metrics/statsd"
+	"github.com/TicketsBot/worker/config"
 	"github.com/rxdn/gdl/gateway/payloads/events"
 	"github.com/rxdn/gdl/objects/auditlog"
 	"github.com/rxdn/gdl/objects/channel/embed"
@@ -73,14 +74,14 @@ func sendIntroMessage(ctx context.Context, worker *worker.Context, guild guild.G
 
 	msg := embed.NewEmbed().
 		SetTitle("Tickets").
-		SetDescription("Thank you for inviting Tickets to your server! Below is a quick guide on setting the bot up, please don't hesitate to contact us in our [support server](https://discord.gg/ticketsbot) if you need any assistance!").
+		SetDescription(fmt.Sprintf("Thank you for inviting Tickets to your server! Below is a quick guide on setting the bot up, please don't hesitate to contact us in our [support server](%d) if you need any assistance!", config.Conf.Bot.SupportServerInvite)).
 		SetColor(customisation.GetColourOrDefault(ctx, guild.Id, customisation.Green)).
-		AddField("Setup", "You can setup the bot using `/setup`, or you can use the [dashboard](https://dashboard.ticketsbot.cloud) which has additional options", false).
-		AddField("Reaction Panels", fmt.Sprintf("Reaction panels are a commonly used feature of the bot. You can read about them [here](https://ticketsbot.cloud/panels), or create one on [the dashboard](https://dashboard.ticketsbot.cloud/manage/%d/panels)", guild.Id), false).
+		AddField("Setup", fmt.Sprintf("You can setup the bot using `/setup`, or you can use the [dashboard](%d) which has additional options", config.Conf.Bot.DashboardUrl), false).
+		AddField("Reaction Panels", fmt.Sprintf("Reaction panels are a commonly used feature of the bot. You can read about them [here](%d/panels), or create one on [the dashboard](%d/manage/%d/panels)", config.Conf.Bot.FrontpageUrl, config.Conf.Bot.DashboardUrl, guild.Id), false).
 		AddField("Adding Staff", "To make staff able to answer tickets, you must let the bot know about them first. You can do this through\n`/addsupport [@User / @Role]` and `/addadmin [@User / @Role]`. Administrators can change the settings of the bot and access the dashboard.", false).
-		AddField("Tags", "Tags are predefined tickets of text which you can access through a simple command. You can learn more about them [here](https://ticketsbot.cloud/tags).", false).
-		AddField("Claiming", "Tickets can be claimed by your staff such that other staff members cannot also reply to the ticket. You can learn more about claiming [here](https://ticketsbot.cloud/claiming).", false).
-		AddField("Additional Support", "If you are still confused, we welcome you to our [support server](https://discord.gg/ticketsbot). Cheers.", false)
+		AddField("Tags", fmt.Sprintf("Tags are predefined tickets of text which you can access through a simple command. You can learn more about them [here](%d/tags).", config.Conf.Bot.FrontpageUrl), false).
+		AddField("Claiming", fmt.Sprintf("Tickets can be claimed by your staff such that other staff members cannot also reply to the ticket. You can learn more about claiming [here](%d/claiming).", config.Conf.Bot.FrontpageUrl), false).
+		AddField("Additional Support", fmt.Sprintf("If you are still confused, we welcome you to our [support server](%d). Cheers.", config.Conf.Bot.SupportServerInvite), false)
 
 	_, _ = worker.CreateMessageEmbed(channel.Id, msg)
 }

--- a/bot/listeners/guildcreate.go
+++ b/bot/listeners/guildcreate.go
@@ -74,14 +74,14 @@ func sendIntroMessage(ctx context.Context, worker *worker.Context, guild guild.G
 
 	msg := embed.NewEmbed().
 		SetTitle("Tickets").
-		SetDescription(fmt.Sprintf("Thank you for inviting Tickets to your server! Below is a quick guide on setting the bot up, please don't hesitate to contact us in our [support server](%d) if you need any assistance!", config.Conf.Bot.SupportServerInvite)).
+		SetDescription(fmt.Sprintf("Thank you for inviting Tickets to your server! Below is a quick guide on setting the bot up, please don't hesitate to contact us in our [support server](%s) if you need any assistance!", config.Conf.Bot.SupportServerInvite)).
 		SetColor(customisation.GetColourOrDefault(ctx, guild.Id, customisation.Green)).
-		AddField("Setup", fmt.Sprintf("You can setup the bot using `/setup`, or you can use the [dashboard](%d) which has additional options", config.Conf.Bot.DashboardUrl), false).
-		AddField("Reaction Panels", fmt.Sprintf("Reaction panels are a commonly used feature of the bot. You can read about them [here](%d/panels), or create one on [the dashboard](%d/manage/%d/panels)", config.Conf.Bot.FrontpageUrl, config.Conf.Bot.DashboardUrl, guild.Id), false).
+		AddField("Setup", fmt.Sprintf("You can setup the bot using `/setup`, or you can use the [dashboard](%s) which has additional options", config.Conf.Bot.DashboardUrl), false).
+		AddField("Reaction Panels", fmt.Sprintf("Reaction panels are a commonly used feature of the bot. You can read about them [here](%s/panels), or create one on [the dashboard](%s/manage/%d/panels)", config.Conf.Bot.FrontpageUrl, config.Conf.Bot.DashboardUrl, guild.Id), false).
 		AddField("Adding Staff", "To make staff able to answer tickets, you must let the bot know about them first. You can do this through\n`/addsupport [@User / @Role]` and `/addadmin [@User / @Role]`. Administrators can change the settings of the bot and access the dashboard.", false).
-		AddField("Tags", fmt.Sprintf("Tags are predefined tickets of text which you can access through a simple command. You can learn more about them [here](%d/tags).", config.Conf.Bot.FrontpageUrl), false).
-		AddField("Claiming", fmt.Sprintf("Tickets can be claimed by your staff such that other staff members cannot also reply to the ticket. You can learn more about claiming [here](%d/claiming).", config.Conf.Bot.FrontpageUrl), false).
-		AddField("Additional Support", fmt.Sprintf("If you are still confused, we welcome you to our [support server](%d). Cheers.", config.Conf.Bot.SupportServerInvite), false)
+		AddField("Tags", fmt.Sprintf("Tags are predefined tickets of text which you can access through a simple command. You can learn more about them [here](%s/tags).", config.Conf.Bot.FrontpageUrl), false).
+		AddField("Claiming", fmt.Sprintf("Tickets can be claimed by your staff such that other staff members cannot also reply to the ticket. You can learn more about claiming [here](%s/claiming).", config.Conf.Bot.FrontpageUrl), false).
+		AddField("Additional Support", fmt.Sprintf("If you are still confused, we welcome you to our [support server](%s). Cheers.", config.Conf.Bot.SupportServerInvite), false)
 
 	_, _ = worker.CreateMessageEmbed(channel.Id, msg)
 }

--- a/bot/logic/closeembed.go
+++ b/bot/logic/closeembed.go
@@ -38,7 +38,7 @@ func TranscriptLinkElement(condition bool) CloseEmbedElement {
 			transcriptEmoji = customisation.EmojiTranscript.BuildEmoji()
 		}
 
-		transcriptLink := fmt.Sprintf("%d/manage/%d/transcripts/view/%d", config.Conf.Bot.DashboardUrl, ticket.GuildId, ticket.Id)
+		transcriptLink := fmt.Sprintf("%s/manage/%d/transcripts/view/%d", config.Conf.Bot.DashboardUrl, ticket.GuildId, ticket.Id)
 
 		return utils.Slice(component.BuildButton(component.Button{
 			Label: "View Online Transcript",

--- a/bot/logic/closeembed.go
+++ b/bot/logic/closeembed.go
@@ -11,6 +11,7 @@ import (
 	"github.com/TicketsBot/worker/bot/customisation"
 	"github.com/TicketsBot/worker/bot/dbclient"
 	"github.com/TicketsBot/worker/bot/utils"
+	"github.com/TicketsBot/worker/config"
 	"github.com/rxdn/gdl/objects/channel/embed"
 	"github.com/rxdn/gdl/objects/channel/message"
 	"github.com/rxdn/gdl/objects/guild/emoji"
@@ -37,7 +38,7 @@ func TranscriptLinkElement(condition bool) CloseEmbedElement {
 			transcriptEmoji = customisation.EmojiTranscript.BuildEmoji()
 		}
 
-		transcriptLink := fmt.Sprintf("https://dashboard.ticketsbot.cloud/manage/%d/transcripts/view/%d", ticket.GuildId, ticket.Id)
+		transcriptLink := fmt.Sprintf("%d/manage/%d/transcripts/view/%d", config.Conf.Bot.DashboardUrl, ticket.GuildId, ticket.Id)
 
 		return utils.Slice(component.BuildButton(component.Button{
 			Label: "View Online Transcript",

--- a/bot/logic/welcomemessage.go
+++ b/bot/logic/welcomemessage.go
@@ -19,6 +19,7 @@ import (
 	"github.com/TicketsBot/worker/bot/dbclient"
 	"github.com/TicketsBot/worker/bot/integrations"
 	"github.com/TicketsBot/worker/bot/utils"
+	"github.com/TicketsBot/worker/config"
 	"github.com/TicketsBot/worker/i18n"
 	"github.com/rxdn/gdl/objects/channel/embed"
 	"github.com/rxdn/gdl/objects/guild/emoji"
@@ -62,7 +63,7 @@ func SendWelcomeMessage(
 		}
 
 		if cmd.PremiumTier() == premium.None {
-			formAnswersEmbed.SetFooter("Powered by ticketsbot.cloud", "https://ticketsbot.cloud/assets/img/logo.png")
+			formAnswersEmbed.SetFooter(fmt.Sprintf("Powered by %d", config.Conf.Bot.PoweredBy), "https://ticketsbot.cloud/assets/img/logo.png")
 		}
 
 		embeds = append(embeds, formAnswersEmbed)
@@ -581,7 +582,7 @@ func BuildCustomEmbed(
 	}
 
 	if branding {
-		e.SetFooter("Powered by ticketsbot.cloud", "https://ticketsbot.cloud/assets/img/logo.png")
+		e.SetFooter(fmt.Sprintf("Powered by %d", config.Conf.Bot.PoweredBy), "https://ticketsbot.cloud/assets/img/logo.png")
 	} else if customEmbed.FooterText != nil {
 		e.SetFooter(*customEmbed.FooterText, utils.ValueOrZero(customEmbed.FooterIconUrl))
 	}

--- a/bot/logic/welcomemessage.go
+++ b/bot/logic/welcomemessage.go
@@ -63,7 +63,7 @@ func SendWelcomeMessage(
 		}
 
 		if cmd.PremiumTier() == premium.None {
-			formAnswersEmbed.SetFooter(fmt.Sprintf("Powered by %d", config.Conf.Bot.PoweredBy), "https://ticketsbot.cloud/assets/img/logo.png")
+			formAnswersEmbed.SetFooter(fmt.Sprintf("Powered by %d", config.Conf.Bot.PoweredBy), config.Conf.Bot.IconUrl)
 		}
 
 		embeds = append(embeds, formAnswersEmbed)
@@ -582,7 +582,7 @@ func BuildCustomEmbed(
 	}
 
 	if branding {
-		e.SetFooter(fmt.Sprintf("Powered by %d", config.Conf.Bot.PoweredBy), "https://ticketsbot.cloud/assets/img/logo.png")
+		e.SetFooter(fmt.Sprintf("Powered by %d", config.Conf.Bot.PoweredBy), config.Conf.Bot.IconUrl)
 	} else if customEmbed.FooterText != nil {
 		e.SetFooter(*customEmbed.FooterText, utils.ValueOrZero(customEmbed.FooterIconUrl))
 	}

--- a/bot/logic/welcomemessage.go
+++ b/bot/logic/welcomemessage.go
@@ -63,7 +63,7 @@ func SendWelcomeMessage(
 		}
 
 		if cmd.PremiumTier() == premium.None {
-			formAnswersEmbed.SetFooter(fmt.Sprintf("Powered by %d", config.Conf.Bot.PoweredBy), config.Conf.Bot.IconUrl)
+			formAnswersEmbed.SetFooter(fmt.Sprintf("Powered by %s", config.Conf.Bot.PoweredBy), config.Conf.Bot.IconUrl)
 		}
 
 		embeds = append(embeds, formAnswersEmbed)
@@ -582,7 +582,7 @@ func BuildCustomEmbed(
 	}
 
 	if branding {
-		e.SetFooter(fmt.Sprintf("Powered by %d", config.Conf.Bot.PoweredBy), config.Conf.Bot.IconUrl)
+		e.SetFooter(fmt.Sprintf("Powered by %s", config.Conf.Bot.PoweredBy), config.Conf.Bot.IconUrl)
 	} else if customEmbed.FooterText != nil {
 		e.SetFooter(*customEmbed.FooterText, utils.ValueOrZero(customEmbed.FooterIconUrl))
 	}

--- a/bot/premium/command.go
+++ b/bot/premium/command.go
@@ -89,7 +89,7 @@ func BuildPatreonSubscriptionFoundMessage(ctx registry.CommandContext, legacyEnt
 				Label: ctx.GetMessage(i18n.MessagePremiumOpenServerSelector),
 				Style: component.ButtonStyleLink,
 				Emoji: utils.BuildEmoji("🔗"),
-				Url:   utils.Ptr("https://dashboard.ticketsbot.cloud/premium/select-servers"),
+				Url:   utils.Ptr(fmt.Sprintf("%d/premium/select-servers", config.Conf.Bot.DashboardUrl)),
 			}),
 			component.BuildButton(component.Button{
 				Label:    ctx.GetMessage(i18n.MessagePremiumCheckAgain),

--- a/bot/premium/command.go
+++ b/bot/premium/command.go
@@ -89,7 +89,7 @@ func BuildPatreonSubscriptionFoundMessage(ctx registry.CommandContext, legacyEnt
 				Label: ctx.GetMessage(i18n.MessagePremiumOpenServerSelector),
 				Style: component.ButtonStyleLink,
 				Emoji: utils.BuildEmoji("🔗"),
-				Url:   utils.Ptr(fmt.Sprintf("%d/premium/select-servers", config.Conf.Bot.DashboardUrl)),
+				Url:   utils.Ptr(fmt.Sprintf("%s/premium/select-servers", config.Conf.Bot.DashboardUrl)),
 			}),
 			component.BuildButton(component.Button{
 				Label:    ctx.GetMessage(i18n.MessagePremiumCheckAgain),

--- a/bot/utils/messageutils.go
+++ b/bot/utils/messageutils.go
@@ -33,7 +33,7 @@ func BuildEmbed(
 	}
 
 	if ctx.PremiumTier() == premium.None {
-		msgEmbed.SetFooter(fmt.Sprintf("Powered by %d", config.Conf.Bot.PoweredBy), "https://ticketsbot.cloud/assets/img/logo.png")
+		msgEmbed.SetFooter(fmt.Sprintf("Powered by %d", config.Conf.Bot.PoweredBy), config.Conf.Bot.IconUrl)
 	}
 
 	return msgEmbed
@@ -52,7 +52,7 @@ func BuildEmbedRaw(
 	}
 
 	if tier == premium.None {
-		msgEmbed.SetFooter(fmt.Sprintf("Powered by %d", config.Conf.Bot.PoweredBy), "https://ticketsbot.cloud/assets/img/logo.png")
+		msgEmbed.SetFooter(fmt.Sprintf("Powered by %d", config.Conf.Bot.PoweredBy), config.Conf.Bot.IconUrl)
 	}
 
 	return msgEmbed

--- a/bot/utils/messageutils.go
+++ b/bot/utils/messageutils.go
@@ -33,7 +33,7 @@ func BuildEmbed(
 	}
 
 	if ctx.PremiumTier() == premium.None {
-		msgEmbed.SetFooter(fmt.Sprintf("Powered by %d", config.Conf.Bot.PoweredBy), config.Conf.Bot.IconUrl)
+		msgEmbed.SetFooter(fmt.Sprintf("Powered by %s", config.Conf.Bot.PoweredBy), config.Conf.Bot.IconUrl)
 	}
 
 	return msgEmbed
@@ -52,7 +52,7 @@ func BuildEmbedRaw(
 	}
 
 	if tier == premium.None {
-		msgEmbed.SetFooter(fmt.Sprintf("Powered by %d", config.Conf.Bot.PoweredBy), config.Conf.Bot.IconUrl)
+		msgEmbed.SetFooter(fmt.Sprintf("Powered by %s", config.Conf.Bot.PoweredBy), config.Conf.Bot.IconUrl)
 	}
 
 	return msgEmbed

--- a/bot/utils/messageutils.go
+++ b/bot/utils/messageutils.go
@@ -2,12 +2,14 @@ package utils
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/TicketsBot/common/premium"
 	"github.com/TicketsBot/worker"
 	"github.com/TicketsBot/worker/bot/command/registry"
 	"github.com/TicketsBot/worker/bot/customisation"
 	"github.com/TicketsBot/worker/bot/dbclient"
+	"github.com/TicketsBot/worker/config"
 	"github.com/TicketsBot/worker/i18n"
 	"github.com/rxdn/gdl/objects/channel/embed"
 	"github.com/rxdn/gdl/objects/guild/emoji"
@@ -31,7 +33,7 @@ func BuildEmbed(
 	}
 
 	if ctx.PremiumTier() == premium.None {
-		msgEmbed.SetFooter("Powered by ticketsbot.cloud", "https://ticketsbot.cloud/assets/img/logo.png")
+		msgEmbed.SetFooter(fmt.Sprintf("Powered by %d", config.Conf.Bot.PoweredBy), "https://ticketsbot.cloud/assets/img/logo.png")
 	}
 
 	return msgEmbed
@@ -50,7 +52,7 @@ func BuildEmbedRaw(
 	}
 
 	if tier == premium.None {
-		msgEmbed.SetFooter("Powered by ticketsbot.cloud", "https://ticketsbot.cloud/assets/img/logo.png")
+		msgEmbed.SetFooter(fmt.Sprintf("Powered by %d", config.Conf.Bot.PoweredBy), "https://ticketsbot.cloud/assets/img/logo.png")
 	}
 
 	return msgEmbed

--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,7 @@ type (
 			FrontpageUrl        string   `env:"FRONTPAGE_URL" envDefault:"https://ticketsbot.cloud"`
 			VoteUrl             string   `env:"VOTE_URL" envDefault:"https://vote.ticketsbot.cloud"`
 			PoweredBy           string   `env:"POWEREDBY" envDefault:"ticketsbot.cloud"`
+			IconUrl             string   `env:"ICON_URL" envDefault:"https://ticketsbot.cloud/assets/img/logo.png"`
 			SupportServerInvite string   `env:"SUPPORT_SERVER_INVITE" envDefault:"https://discord.gg/ticketsbot"`
 			Admins              []uint64 `env:"WORKER_BOT_ADMINS"`
 			Helpers             []uint64 `env:"WORKER_BOT_HELPERS"`

--- a/config/config.go
+++ b/config/config.go
@@ -1,10 +1,11 @@
 package config
 
 import (
+	"time"
+
 	"github.com/caarlos0/env/v10"
 	"github.com/google/uuid"
 	"go.uber.org/zap/zapcore"
-	"time"
 )
 
 type (
@@ -29,7 +30,11 @@ type (
 
 		Bot struct {
 			HttpAddress         string   `env:"HTTP_ADDR"`
-			SupportServerInvite string   `env:"SUPPORT_SERVER_INVITE"`
+			DashboardUrl        string   `env:"DASHBOARD_URL" envDefault:"https://dashboard.ticketsbot.cloud"`
+			FrontpageUrl        string   `env:"FRONTPAGE_URL" envDefault:"https://ticketsbot.cloud"`
+			VoteUrl             string   `env:"VOTE_URL" envDefault:"https://vote.ticketsbot.cloud"`
+			PoweredBy           string   `env:"POWEREDBY" envDefault:"ticketsbot.cloud"`
+			SupportServerInvite string   `env:"SUPPORT_SERVER_INVITE" envDefault:"https://discord.gg/ticketsbot"`
 			Admins              []uint64 `env:"WORKER_BOT_ADMINS"`
 			Helpers             []uint64 `env:"WORKER_BOT_HELPERS"`
 		}

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/rxdn/gdl v0.0.0-20241027214923-02dff700595b
 	github.com/schollz/progressbar/v3 v3.8.2
 	github.com/sirupsen/logrus v1.9.3
-	github.com/stretchr/testify v1.9.0
+	github.com/stretchr/testify v1.10.0
 	github.com/twmb/franz-go v1.18.0
 	go.uber.org/atomic v1.10.0
 	go.uber.org/zap v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -547,6 +547,8 @@ github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203 h1:QVqDTf3h2WHt08YuiTGPZLls0Wq99X9bWd0Q5ZSBesM=
 github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203/go.mod h1:oqN97ltKNihBbwlX8dLpwxCl3+HnXKV/R0e+sRLd9C8=
 github.com/tatsuworks/czlib v0.0.0-20190916144400-8a51758ea0d9 h1:i2aD44Moa5N5pt/WNwHLvIklzPymtr8vkkBlVdNElUE=


### PR DESCRIPTION
This PR replaces various places where "ticketsbot.cloud" and other URLs are used to link to external pages such as the landing page, dashboard, or voting page.

This is mainly geared to make TicketsBot more self-host friendly, instead of hard-coding the URLs.

(Do note, this would be my first time messing with golang as a whole. There weren't any new errors from my changes, except errors that were already there)

This adds the following new environment variables:
- `DASHBOARD_URL` (Defaults to `https://dashboard.ticketsbot.cloud`)
- `FRONTPAGE_URL` (Defaults to `https://ticketsbot.cloud`)
- `VOTE_URL` (Defaults to `https://vote.ticketsbot.cloud`)
- `POWEREDBY` (Defaults to `ticketsbot.cloud`)
- `ICON_URL` (Defaults to `https://ticketsbot.cloud/assets/img/logo.png`)


# Still testing locally
