### PR TITLE
Improve handling of empty sources and conditional fields

### DIFF
--- a/bot/command/impl/admin/admincheckpremium.go
+++ b/bot/command/impl/admin/admincheckpremium.go
@@ -55,12 +55,16 @@ func (AdminCheckPremiumCommand) Execute(ctx registry.CommandContext, raw string)
 		return
 	}
 
+	sourceFormatted := string(src)
+	if sourceFormatted == "" {
+		sourceFormatted = "None"
+	}
 	ctx.ReplyWith(command.NewMessageResponseWithComponents(utils.Slice(
 		utils.BuildContainerRaw(
 			ctx,
 			customisation.Orange,
 			"Admin - Premium Check",
-			fmt.Sprintf("**Server Name:** `%s`\n**Owner:** <@%d> `%d`\n**Premium Tier:** `%s`\n**Premium Source:** `%s`", guild.Name, guild.OwnerId, guild.OwnerId, tier.String(), src),
+			fmt.Sprintf("**Server Name:** `%s`\n**Owner:** <@%d> `%d`\n**Premium Tier:** `%s`\n**Premium Source:** `%s`", guild.Name, guild.OwnerId, guild.OwnerId, tier.String(), sourceFormatted),
 		),
 	)))
 }

--- a/bot/command/impl/admin/admindebug.go
+++ b/bot/command/impl/admin/admindebug.go
@@ -197,16 +197,13 @@ func (AdminDebugCommand) Execute(ctx registry.CommandContext, raw string) {
 	settingsInfo = append(settingsInfo, fmt.Sprintf("Data Imported: `%t`", hasDataRun))
 	settingsInfo = append(settingsInfo, fmt.Sprintf("Transcripts Imported: `%t`", hasTranscriptRun))
 
-	featuresMsg := ""
-
-	if len(featuresEnabled) > 0 {
-		featuresMsg = fmt.Sprintf("**Experiments Enabled**\n- %s", strings.Join(featuresEnabled, "\n- "))
-	}
-
 	debugResponse := []string{
 		fmt.Sprintf("**Guild Info**\n- %s", strings.Join(guildInfo, "\n- ")),
 		fmt.Sprintf("**Settings**\n- %s", strings.Join(settingsInfo, "\n- ")),
-		featuresMsg,
+	}
+
+	if len(featuresEnabled) > 0 {
+		debugResponse = append(debugResponse, fmt.Sprintf("**Experiments Enabled**\n- %s", strings.Join(featuresEnabled, "\n- ")))
 	}
 
 	ctx.ReplyWith(command.NewEphemeralMessageResponseWithComponents([]component.Component{

--- a/bot/command/impl/admin/adminlistguildentitlements.go
+++ b/bot/command/impl/admin/adminlistguildentitlements.go
@@ -100,11 +100,15 @@ func (AdminListGuildEntitlementsCommand) Execute(ctx registry.CommandContext, gu
 	innerComponents := []component.Component{}
 
 	for _, entitlement := range entitlements {
+		sourceFormatted := string(entitlement.Source)
+		if sourceFormatted == "" {
+			sourceFormatted = "None"
+		}
 		value := fmt.Sprintf(
 			"####%s\n\n**Tier:** %s\n**Source:** %s\n**Expires:** <t:%d>\n**SKU ID:** %s\n**SKU Priority:** %d\n\n",
 			entitlement.SkuLabel,
 			entitlement.Tier,
-			entitlement.Source,
+			sourceFormatted,
 			entitlement.ExpiresAt.Unix(),
 			entitlement.SkuId.String(),
 			entitlement.SkuPriority,

--- a/bot/command/impl/admin/adminlistuserentitlements.go
+++ b/bot/command/impl/admin/adminlistuserentitlements.go
@@ -53,12 +53,15 @@ func (AdminListUserEntitlementsCommand) Execute(ctx registry.CommandContext, use
 	innerComponents := []component.Component{}
 
 	for _, entitlement := range entitlements {
-
+		sourceFormatted := string(entitlement.Source)
+		if sourceFormatted == "" {
+			sourceFormatted = "None"
+		}
 		value := fmt.Sprintf(
 			"#### %s\n\n**Tier:** %s\n**Source:** %s\n**Expires:** <t:%d>\n**SKU ID:** %s\n**SKU Priority:** %d\n\n",
 			entitlement.SkuLabel,
 			entitlement.Tier,
-			entitlement.Source,
+			sourceFormatted,
 			entitlement.ExpiresAt.Unix(),
 			entitlement.SkuId.String(),
 			entitlement.SkuPriority,

--- a/bot/command/impl/admin/adminwhitelabeldata.go
+++ b/bot/command/impl/admin/adminwhitelabeldata.go
@@ -117,10 +117,16 @@ func (AdminWhitelabelDataCommand) Execute(ctx registry.CommandContext, userId ui
 	fields := []model.Field{
 		{Name: "Subscription Tier", Value: tier.String()},
 		{Name: "Bot ID", Value: botIdFormatted},
-		{Name: "Public Key", Value: publicKeyFormatted},
-		{Name: "Guilds", Value: guildsFormatted},
-		{Name: "Last 3 Errors", Value: errorsFormatted},
-		{Name: "Invite Link", Value: fmt.Sprintf("[Click Here](https://discord.com/oauth2/authorize?client_id=%d&scope=bot+applications.commands&permissions=395942816984)", data.BotId)},
+	}
+
+	if data.BotId != 0 {
+		fields = append(fields, model.Field{Name: "Public Key", Value: publicKeyFormatted})
+		fields = append(fields, model.Field{Name: "Guilds", Value: guildsFormatted})
+		fields = append(fields, model.Field{Name: "Last 3 Errors", Value: errorsFormatted})
+		fields = append(fields, model.Field{
+			Name:  "Invite Link",
+			Value: fmt.Sprintf("[Click Here](https://discord.com/oauth2/authorize?client_id=%d&scope=bot+applications.commands&permissions=395942816984)", data.BotId),
+		})
 	}
 
 	for i := range fields {

--- a/experiments/experiments.go
+++ b/experiments/experiments.go
@@ -43,12 +43,12 @@ func HasFeature(ctx context.Context, guildId uint64, experiment Experiment) bool
 			if dbErr != nil || dbExperiment == nil {
 				// If we can't find it in the database, default to 0%
 				rolloutPercentage = 0
+			} else {
+				rolloutPercentage = dbExperiment.RolloutPercentage
+
+				// Cache in Redis for future use
+				_ = redis.SetExperimentRolloutPercentage(ctx, strings.ToLower(string(experiment)), rolloutPercentage)
 			}
-
-			rolloutPercentage = dbExperiment.RolloutPercentage
-
-			// Cache in Redis for future use
-			_ = redis.SetExperimentRolloutPercentage(ctx, strings.ToLower(string(experiment)), rolloutPercentage)
 		} else {
 			rolloutPercentage = 0
 		}


### PR DESCRIPTION
This update standardizes the display of empty 'Source' fields as 'None' in admin premium and entitlement commands, ensuring clearer output. It also adjusts the admin debug command to only show enabled experiments if present, and makes whitelabel data fields conditional on Bot ID presence. Additionally, the experiments package now correctly caches rollout percentages only when a database experiment is found.