### PR TITLE
RM-250: Fix join ticket does not update for per panel thread mode

### DIFF
--- a/bot/button/handlers/jointhread.go
+++ b/bot/button/handlers/jointhread.go
@@ -7,14 +7,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/TicketsBot-cloud/common/sentry"
-	"github.com/TicketsBot-cloud/database"
 	"github.com/TicketsBot-cloud/worker/bot/button/registry"
 	"github.com/TicketsBot-cloud/worker/bot/button/registry/matcher"
 	"github.com/TicketsBot-cloud/worker/bot/command/context"
 	"github.com/TicketsBot-cloud/worker/bot/customisation"
 	"github.com/TicketsBot-cloud/worker/bot/dbclient"
-	"github.com/TicketsBot-cloud/worker/bot/errorcontext"
 	"github.com/TicketsBot-cloud/worker/bot/logic"
 	"github.com/TicketsBot-cloud/worker/i18n"
 )
@@ -94,42 +91,6 @@ func (h *JoinThreadHandler) Execute(ctx *context.ButtonContext) {
 	if err := ctx.Worker().AddThreadMember(*ticket.ChannelId, ctx.UserId()); err != nil {
 		ctx.HandleError(err)
 		return
-	}
-
-	// Update ticket's member count
-	if ticket.JoinMessageId != nil {
-		var panel *database.Panel
-		if ticket.PanelId != nil {
-			tmp, err := dbclient.Client.Panel.GetById(ctx, *ticket.PanelId)
-			if err != nil {
-				ctx.HandleError(err)
-				return
-			}
-
-			if tmp.PanelId != 0 && ctx.GuildId() == tmp.GuildId {
-				panel = &tmp
-			}
-		}
-
-		threadStaff, err := logic.GetStaffInThread(ctx, ctx.Worker(), ticket, *ticket.ChannelId)
-		if err != nil {
-			ctx.HandleError(err)
-			return
-		}
-
-		settings, err := dbclient.Client.Settings.Get(ctx, ctx.GuildId())
-		if err != nil {
-			ctx.HandleError(err)
-			return
-		}
-
-		if settings.TicketNotificationChannel != nil {
-			name, _ := logic.GenerateChannelName(ctx, ctx.Worker(), panel, ticket.GuildId, ticket.Id, ticket.UserId, nil)
-			data := logic.BuildJoinThreadMessage(ctx, ctx.Worker(), ticket.GuildId, ticket.UserId, name, ticket.Id, panel, threadStaff, ctx.PremiumTier())
-			if _, err := ctx.Worker().EditMessage(*settings.TicketNotificationChannel, *ticket.JoinMessageId, data.IntoEditMessageData()); err != nil {
-				sentry.ErrorWithContext(err, errorcontext.WorkerErrorContext{Guild: ctx.GuildId()})
-			}
-		}
 	}
 
 	ctx.Reply(customisation.Green, i18n.Success, i18n.MessageJoinThreadSuccess, *ticket.ChannelId)

--- a/bot/command/impl/tickets/switchpanel.go
+++ b/bot/command/impl/tickets/switchpanel.go
@@ -243,17 +243,26 @@ func (SwitchPanelCommand) Execute(ctx *cmdcontext.SlashCommandContext, panelId i
 		ctx.ReplyRaw(customisation.Green, "Success", fmt.Sprintf("This ticket has been switched to the panel **%s**.\n\nNote: As this is a thread, the permissions could not be bulk updated.", newPanel.Title))
 
 		// Modify join message
-		if ticket.JoinMessageId != nil && settings.TicketNotificationChannel != nil {
-			threadStaff, err := logic.GetStaffInThread(ctx.Context, ctx.Worker(), ticket, *ticket.ChannelId)
-			if err != nil {
-				sentry.ErrorWithContext(err, ctx.ToErrorContext()) // Only log
-				return
+		if ticket.JoinMessageId != nil {
+			var notificationChannel *uint64
+			if newPanel.TicketNotificationChannel != nil {
+				notificationChannel = newPanel.TicketNotificationChannel
+			} else if settings.TicketNotificationChannel != nil {
+				notificationChannel = settings.TicketNotificationChannel
 			}
 
-			msg := logic.BuildJoinThreadMessage(ctx.Context, ctx.Worker(), ctx.GuildId(), ticket.UserId, newChannelName, ticket.Id, &newPanel, threadStaff, ctx.PremiumTier())
-			if _, err := ctx.Worker().EditMessage(*settings.TicketNotificationChannel, *ticket.JoinMessageId, msg.IntoEditMessageData()); err != nil {
-				sentry.ErrorWithContext(err, ctx.ToErrorContext()) // Only log
-				return
+			if notificationChannel != nil {
+				threadStaff, err := logic.GetStaffInThread(ctx.Context, ctx.Worker(), ticket, *ticket.ChannelId)
+				if err != nil {
+					sentry.ErrorWithContext(err, ctx.ToErrorContext()) // Only log
+					return
+				}
+
+				msg := logic.BuildJoinThreadMessage(ctx.Context, ctx.Worker(), ctx.GuildId(), ticket.UserId, newChannelName, ticket.Id, &newPanel, threadStaff, ctx.PremiumTier())
+				if _, err := ctx.Worker().EditMessage(*notificationChannel, *ticket.JoinMessageId, msg.IntoEditMessageData()); err != nil {
+					sentry.ErrorWithContext(err, ctx.ToErrorContext()) // Only log
+					return
+				}
 			}
 		}
 

--- a/bot/listeners/threadmembersupdate.go
+++ b/bot/listeners/threadmembersupdate.go
@@ -60,10 +60,17 @@ func OnThreadMembersUpdate(worker *worker.Context, e events.ThreadMembersUpdate)
 			return
 		}
 
-		if settings.TicketNotificationChannel != nil {
+		var notificationChannel *uint64
+		if panel != nil && panel.TicketNotificationChannel != nil {
+			notificationChannel = panel.TicketNotificationChannel
+		} else if settings.TicketNotificationChannel != nil {
+			notificationChannel = settings.TicketNotificationChannel
+		}
+
+		if notificationChannel != nil {
 			name, _ := logic.GenerateChannelName(ctx, worker, panel, ticket.GuildId, ticket.Id, ticket.UserId, nil)
 			data := logic.BuildJoinThreadMessage(ctx, worker, ticket.GuildId, ticket.UserId, name, ticket.Id, panel, threadStaff, premiumTier)
-			if _, err := worker.EditMessage(*settings.TicketNotificationChannel, *ticket.JoinMessageId, data.IntoEditMessageData()); err != nil {
+			if _, err := worker.EditMessage(*notificationChannel, *ticket.JoinMessageId, data.IntoEditMessageData()); err != nil {
 				sentry.ErrorWithContext(err, errorcontext.WorkerErrorContext{Guild: e.GuildId})
 			}
 		}


### PR DESCRIPTION
## Description
This pull request fixes the join ticket not updating when a staff joins if using per panel thread mode

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing
Only Use per panel thread mode
Join the ticket with another user
The join ticket should then update

## Checklist
- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
