### PR TITLE
RM-253: Delete pin notifications using DB lookup

### DIFF
--- a/bot/listeners/message.go
+++ b/bot/listeners/message.go
@@ -40,19 +40,22 @@ func OnMessage(worker *worker.Context, e events.MessageCreate) {
 		return
 	}
 
-	ticket, isTicket, err := getTicket(span.Context(), e.ChannelId)
-	if err != nil {
-		sentry.ErrorWithContext(err, utils.MessageCreateErrorContext(e))
+	// Delete pin notification messages in ticket channels.
+	if e.Type == message.MessageTypeChannelPinnedMessage && e.Author.Id == worker.BotId {
+		ticket, ok, err := dbclient.Client.Tickets.GetByChannel(span.Context(), e.ChannelId)
+		if err == nil && ok && ticket.Id != 0 {
+			sentry.WithSpan0(span.Context(), "Delete pin notification", func(span *sentry.Span) {
+				if err := worker.DeleteMessage(e.ChannelId, e.Id); err != nil {
+					sentry.ErrorWithContext(err, utils.MessageCreateErrorContext(e))
+				}
+			})
+		}
 		return
 	}
 
-	// Delete pin notification messages in ticket channels
-	if isTicket && ticket.Id != 0 && e.Type == message.MessageTypeChannelPinnedMessage && e.Author.Id == worker.BotId {
-		sentry.WithSpan0(span.Context(), "Delete pin notification", func(span *sentry.Span) {
-			if err := worker.DeleteMessage(e.ChannelId, e.Id); err != nil {
-				sentry.ErrorWithContext(err, utils.MessageCreateErrorContext(e))
-			}
-		})
+	ticket, isTicket, err := getTicket(span.Context(), e.ChannelId)
+	if err != nil {
+		sentry.ErrorWithContext(err, utils.MessageCreateErrorContext(e))
 		return
 	}
 


### PR DESCRIPTION
## Description
Handle channel-pinned bot notifications by querying the tickets DB directly instead of the cached getTicket path. This avoids a race where thread message events can be cached as "not a ticket" before SetChannelId commits. If a pinned-message event from the bot is in a ticket channel. The previous getTicket-based check was reorganized and duplicate logic removed.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing
Open a ticket in thread mode
Does the welcome message get deleted? if yes then it works xD

## Checklist
- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
